### PR TITLE
handle NULL values in get_option

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -8,7 +8,7 @@ mailgun_domain_name <- function() {
 
 get_option <- function(opt) {
   opt_value <- getOption(opt)
-  if (!is.null(opt_value) || !nzchar(opt_value)) {
+  if (is.null(opt_value) || !nzchar(opt_value)) {
     stop("You must set option ", sQuote(opt), " in order to use mailgunner.")
   }
   opt_value

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,7 +8,7 @@ mailgun_domain_name <- function() {
 
 get_option <- function(opt) {
   opt_value <- getOption(opt)
-  if (!nzchar(opt_value)) {
+  if (!is.null(opt_value) || !nzchar(opt_value)) {
     stop("You must set option ", sQuote(opt), " in order to use mailgunner.")
   }
   opt_value


### PR DESCRIPTION
Behavior before PR:
```
> getOption("mailgunner.api_key")
NULL
> get_option("mailgunner.api_key")
Error in if (!nzchar(opt_value)) { : argument is of length zero
```

Behavior after PR:
```
> getOption("mailgunner.api_key")
NULL
> get_option("mailgunner.api_key")
Error:
  You must set option ‘mailgunner.api_key’ in order to use mailgunner.
```